### PR TITLE
Bump dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,11 @@ repository = "https://github.com/rozbb/fujisaki-ringsig"
 documentation = "https://docs.rs/fujisaki_ringsig"
 
 [dependencies]
-blake2 = "0.6"
-curve25519-dalek = "0.13"
-digest = "0.6"
+blake2 = "0.9"
+curve25519-dalek = "3.0"
+digest = "0.9" # same as blake2
 generic-array = "0.9"
-rand = "0.3"
+rand_core = { version = "0.5", default-features = false } # same as curve25519-dalek
+
+[dev-dependencies]
+rand = "0.8"

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,7 +1,7 @@
 use curve25519_dalek::constants::RISTRETTO_BASEPOINT_POINT;
 use curve25519_dalek::ristretto::{CompressedRistretto, RistrettoPoint};
 use curve25519_dalek::scalar::Scalar;
-use rand::OsRng;
+use rand_core::OsRng;
 
 /// A public key
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -54,7 +54,7 @@ impl PrivateKey {
         let scalar = {
             let mut arr = [0u8; 32];
             arr.copy_from_slice(scalar_bytes);
-            Scalar(arr)
+            Scalar::from_bits(arr)
         };
         let pubkey_point = {
             let mut arr = [0u8; 32];
@@ -77,7 +77,7 @@ pub struct KeyPair {
 impl KeyPair {
     /// Generate a secure random keypair
     pub fn generate() -> KeyPair {
-        let mut csprng = OsRng::new().expect("Could not instantiate CSPRNG");
+        let mut csprng = OsRng;
         let s = Scalar::random(&mut csprng);
         let pubkey = PublicKey(&s * &RISTRETTO_BASEPOINT_POINT);
         let privkey = PrivateKey(s, pubkey.0.clone());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,8 +48,11 @@
 extern crate curve25519_dalek;
 extern crate digest;
 extern crate generic_array;
-extern crate rand;
+extern crate rand_core;
 extern crate blake2;
+
+#[cfg(test)]
+extern crate rand;
 
 pub mod key;
 pub mod sig;

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -1,6 +1,6 @@
 use sig::{Tag};
 use key::{KeyPair, PrivateKey, PublicKey};
-use rand::{self, Rng};
+use rand::{self, Rng, RngCore};
 
 // Testing context for convenience
 pub(crate) struct Context {
@@ -13,15 +13,15 @@ pub(crate) struct Context {
 pub(crate) fn setup(min_ring_size: usize) -> Context {
     // Make a random issue number, random ring size, and random message to sign
     let mut rng = rand::thread_rng();
-    let msg_len = rng.gen_range(1, 50);
-    let issue_len = rng.gen_range(1, 50);
+    let msg_len = rng.gen_range(1..50);
+    let issue_len = rng.gen_range(1..50);
     let mut msg = vec![0u8; msg_len];
     let mut issue = vec![0u8; issue_len];
 
     rng.fill_bytes(&mut msg);
     rng.fill_bytes(&mut issue);
 
-    let ring_size: usize = rng.gen_range(min_ring_size, 50);
+    let ring_size: usize = rng.gen_range(min_ring_size..50);
 
     // Make a bunch of keypairs
     let mut keypairs = Vec::new();
@@ -47,6 +47,6 @@ pub(crate) fn setup(min_ring_size: usize) -> Context {
 
 pub(crate) fn remove_privkey(keypairs: &mut Vec<KeyPair>) -> PrivateKey {
     let mut rng = rand::thread_rng();
-    let privkey_idx = rng.gen_range(0, keypairs.len());
+    let privkey_idx = rng.gen_range(0..keypairs.len());
     keypairs.remove(privkey_idx).privkey
 }

--- a/src/trace.rs
+++ b/src/trace.rs
@@ -78,11 +78,11 @@ mod test {
 
         // Pick two distinct privkeys to sign with
         let privkey1 = {
-            let privkey_idx = rng.gen_range(0, keypairs.len());
+            let privkey_idx = rng.gen_range(0..keypairs.len());
             keypairs.remove(privkey_idx).privkey
         };
         let privkey2 = {
-            let privkey_idx = rng.gen_range(0, keypairs.len());
+            let privkey_idx = rng.gen_range(0..keypairs.len());
             keypairs.remove(privkey_idx).privkey
         };
 
@@ -101,7 +101,7 @@ mod test {
         // Pick just one privkey to sign with
         let privkey = {
             let mut rng = rand::thread_rng();
-            let privkey_idx = rng.gen_range(0, keypairs.len());
+            let privkey_idx = rng.gen_range(0..keypairs.len());
             keypairs.remove(privkey_idx).privkey
         };
 
@@ -127,7 +127,7 @@ mod test {
         // Pick just one privkey to sign with
         let kp = {
             let mut rng = rand::thread_rng();
-            let privkey_idx = rng.gen_range(0, keypairs.len());
+            let privkey_idx = rng.gen_range(0..keypairs.len());
             keypairs.remove(privkey_idx)
         };
 


### PR DESCRIPTION
Bump dependency versions. Old dependencies were unavailable and this crate didn't compile.

Use of `Blake2s` was changed to `Blake2b`, because `RistrettoPoint::from_hash` did not accept `Digest<OutputSize = U32>` anymore. I don't know if that has any effect on signature. But your tests run so 🤷.  Otherwise I've tried to keep it the same, just update the API where needed.